### PR TITLE
Support CORS

### DIFF
--- a/src/matrix_content_scanner/httpserver.py
+++ b/src/matrix_content_scanner/httpserver.py
@@ -55,7 +55,10 @@ async def simple_cors_middleware(
         # in this case just raises a 405 Method Not Allowed status using an exception.
         # Because we actually want to return a 200 OK with additional headers, we ignore
         # the handler and just return a new response.
-        response = web.StreamResponse(headers=_CORS_HEADERS)
+        response = web.StreamResponse(
+            status=200,
+            headers=_CORS_HEADERS,
+        )
         return response
 
     # Run the request's handler and append CORS headers to it.

--- a/src/matrix_content_scanner/httpserver.py
+++ b/src/matrix_content_scanner/httpserver.py
@@ -38,8 +38,8 @@ _CORS_HEADERS = {
 @web.middleware
 async def simple_cors_middleware(
     request: web.Request,
-    handler: Callable[[web.Request], Awaitable[web.Response]],
-) -> web.Response:
+    handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
+) -> web.StreamResponse:
     """A simple aiohttp middleware that adds CORS headers to responses, and handles
     OPTIONS requests.
 
@@ -55,7 +55,7 @@ async def simple_cors_middleware(
         # in this case just raises a 405 Method Not Allowed status using an exception.
         # Because we actually want to return a 200 OK with additional headers, we ignore
         # the handler and just return a new response.
-        response = web.Response(headers=_CORS_HEADERS)
+        response = web.StreamResponse(headers=_CORS_HEADERS)
         return response
 
     # Run the request's handler and append CORS headers to it.

--- a/src/matrix_content_scanner/httpserver.py
+++ b/src/matrix_content_scanner/httpserver.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import logging
-from typing import TYPE_CHECKING, Callable, Awaitable
+from typing import TYPE_CHECKING, Awaitable, Callable
 
 from aiohttp import web
 
@@ -55,9 +55,7 @@ async def simple_cors_middleware(
         # in this case just raises a 405 Method Not Allowed status using an exception.
         # Because we actually want to return a 200 OK with additional headers, we ignore
         # the handler and just return a new response.
-        response = web.Response(
-            headers=_CORS_HEADERS
-        )
+        response = web.Response(headers=_CORS_HEADERS)
         return response
 
     # Run the request's handler and append CORS headers to it.


### PR DESCRIPTION
Add a simple aiohttp middleware that adds CORS headers to requests, and handle `OPTIONS` requests.

I've also fixed the case of `_MEDIA_PATH_REGEXP` (since it's a constant) while I was there.

Fixes #41 

The list of headers is inspired from https://github.com/matrix-org/matrix-content-scanner/issues/28, except I've reduced the list of allowed methods to `GET, POST, OPTIONS` because we don't handle other ones.