### PR TITLE
Pin CI to Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.11"
       - run: python -m pip install tox
       - run: tox -e check_codestyle
 
@@ -25,9 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          # We're testing Python 3.10 specifically (instead of 3.x) for this job because
-          # python-olm does not have wheels for Python 3.11 yet.
-          python-version: "3.10"
+          python-version: "3.11"
       - run: python -m pip install tox
       - run: tox -e check_types
 
@@ -38,7 +36,7 @@ jobs:
       matrix:
         # Run the unit tests both against our oldest supported Python version
         # and the newest stable.
-        python_version: [ "3.8", "3.x" ]
+        python_version: [ "3.8", "3.11" ]
     steps:
       - run: sudo apt-get install -y libolm-dev libmagic1
       - uses: actions/checkout@v2


### PR DESCRIPTION
Workaround for #50.

I don't know why mypy is failing, but I will fix that in an upcoming PR.