### PR TITLE
Fix typechecking

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,4 @@
 [mypy]
 strict = true
-plugins = mypy_zope:plugin
 # Some calls to Twisted APIs are untyped
 disallow_untyped_calls = false

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,2 @@
 [mypy]
 strict = true
-# Some calls to Twisted APIs are untyped
-disallow_untyped_calls = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ dev =
   tox
   # for type checking
   mypy == 1.7.1
-  mypy-zope
   types-jsonschema
   types-PyYAML
   types-cachetools

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ dev =
   # for tests
   tox
   # for type checking
-  mypy == 0.931
+  mypy == 1.7.1
   mypy-zope
   types-jsonschema
   types-PyYAML

--- a/src/matrix_content_scanner/crypto.py
+++ b/src/matrix_content_scanner/crypto.py
@@ -65,7 +65,7 @@ class CryptoHandler:
             )
 
             # Generate a new key pair and turns it into a pickle.
-            self._decryptor = PkDecryption()
+            self._decryptor = PkDecryption()  # type: ignore[no-untyped-call]
             pickle_bytes = self._decryptor.pickle(passphrase=key)
 
             # Try to write the pickle's content into a file.

--- a/src/matrix_content_scanner/httpserver.py
+++ b/src/matrix_content_scanner/httpserver.py
@@ -130,8 +130,5 @@ class HTTPServer:
             app=self._app,
             host=self._bind_address,
             port=self._bind_port,
-            # We need to ignore mypy's error here because what we do here is correct
-            # according to aiohttp's documentation.
-            # See https://github.com/aio-libs/aiohttp/issues/7077
-            print=None,  # type: ignore[arg-type]
+            print=None,
         )

--- a/src/matrix_content_scanner/logutils.py
+++ b/src/matrix_content_scanner/logutils.py
@@ -30,9 +30,7 @@ def setup_custom_factory() -> None:
 
     def _factory(*args: Any, **kwargs: Any) -> logging.LogRecord:
         record = old_factory(*args, **kwargs)
-        # Define custom attributes on the records. We need to ignore the types here
-        # because otherwise mypy complains the attributes aren't defined on LogRecord.
-        record.request_id = request_id.get(None)  # type: ignore[attr-defined]
+        record.request_id = request_id.get(None)
         return record
 
     logging.setLogRecordFactory(_factory)

--- a/src/matrix_content_scanner/scanner/file_downloader.py
+++ b/src/matrix_content_scanner/scanner/file_downloader.py
@@ -18,7 +18,7 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Dict, Optional, Tuple
 
 import aiohttp
-from multidict import CIMultiDictProxy, MultiDictProxy
+from multidict import CIMultiDictProxy, MultiMapping
 
 from matrix_content_scanner.utils.constants import ErrCode
 from matrix_content_scanner.utils.errors import (
@@ -54,7 +54,7 @@ class FileDownloader:
     async def download_file(
         self,
         media_path: str,
-        thumbnail_params: Optional[MultiDictProxy[str]] = None,
+        thumbnail_params: Optional[MultiMapping[str]] = None,
     ) -> MediaDescription:
         """Retrieve the file with the given `server_name/media_id` path, and stores it on
         disk.
@@ -156,7 +156,7 @@ class FileDownloader:
     async def _get_file_content(
         self,
         url: str,
-        thumbnail_params: Optional[MultiDictProxy[str]],
+        thumbnail_params: Optional[MultiMapping[str]],
     ) -> MediaDescription:
         """Retrieve the content of the file at a given URL.
 
@@ -304,7 +304,7 @@ class FileDownloader:
     async def _get(
         self,
         url: str,
-        query: Optional[MultiDictProxy[str]] = None,
+        query: Optional[MultiMapping[str]] = None,
     ) -> Tuple[int, bytes, CIMultiDictProxy[str]]:
         """Sends a GET request to the provided URL.
 

--- a/src/matrix_content_scanner/scanner/scanner.py
+++ b/src/matrix_content_scanner/scanner/scanner.py
@@ -27,7 +27,7 @@ from humanfriendly import format_size
 from mautrix.crypto.attachments import decrypt_attachment
 from mautrix.errors import DecryptionError
 from mautrix.util import magic
-from multidict import MultiDictProxy
+from multidict import MultiMapping
 
 from matrix_content_scanner.utils.constants import ErrCode
 from matrix_content_scanner.utils.errors import ContentScannerRestError, FileDirtyError
@@ -95,7 +95,7 @@ class Scanner:
         self,
         media_path: str,
         metadata: Optional[JsonDict] = None,
-        thumbnail_params: Optional[MultiDictProxy[str]] = None,
+        thumbnail_params: Optional["MultiMapping[str]"] = None,
     ) -> MediaDescription:
         """Download and scan the given media.
 
@@ -163,7 +163,7 @@ class Scanner:
         cache_key: str,
         media_path: str,
         metadata: Optional[JsonDict] = None,
-        thumbnail_params: Optional[MultiDictProxy[str]] = None,
+        thumbnail_params: Optional[MultiMapping[str]] = None,
     ) -> MediaDescription:
         """Download and scan the given media.
 
@@ -368,7 +368,7 @@ class Scanner:
         self,
         media_path: str,
         metadata: Optional[JsonDict],
-        thumbnail_params: Optional[MultiDictProxy[str]],
+        thumbnail_params: Optional[MultiMapping[str]],
     ) -> str:
         """Generates the key to use to store the result for the given media in the result
         cache.

--- a/tests/scanner/test_file_downloader.py
+++ b/tests/scanner/test_file_downloader.py
@@ -64,7 +64,7 @@ class FileDownloaderTestCase(IsolatedAsyncioTestCase):
 
         # Mock _get so we don't actually try to download files.
         self.get_mock = Mock(side_effect=_get)
-        self.downloader._get = self.get_mock  # type: ignore[assignment]
+        self.downloader._get = self.get_mock  # type: ignore[method-assign]
 
     async def test_download(self) -> None:
         """Tests that downloading a file works."""
@@ -230,7 +230,7 @@ class WellKnownDiscoveryTestCase(IsolatedAsyncioTestCase):
 
         # Mock _get so we don't actually try to download files.
         self.get_mock = Mock(side_effect=_get)
-        self.downloader._get = self.get_mock  # type: ignore[assignment]
+        self.downloader._get = self.get_mock  # type: ignore[method-assign]
 
     async def test_discover(self) -> None:
         """Checks that the base URL to use to download files can be discovered via

--- a/tests/scanner/test_scanner.py
+++ b/tests/scanner/test_scanner.py
@@ -52,7 +52,7 @@ class ScannerTestCase(IsolatedAsyncioTestCase):
 
         # Mock download_file so we don't actually try to download files.
         mcs = get_content_scanner()
-        mcs.file_downloader.download_file = self.downloader_mock  # type: ignore[assignment]
+        mcs.file_downloader.download_file = self.downloader_mock  # type: ignore[method-assign]
         self.scanner = mcs.scanner
 
     async def test_scan(self) -> None:
@@ -161,7 +161,7 @@ class ScannerTestCase(IsolatedAsyncioTestCase):
         """
         # Mock the _run_scan command so we can keep track of its call count.
         mock_runner = Mock(return_value=0)
-        self.scanner._run_scan = mock_runner  # type: ignore[assignment]
+        self.scanner._run_scan = mock_runner  # type: ignore[method-assign]
 
         # Calculate the cache key for this file so we can look it up later.
         cache_key = self.scanner._get_cache_key_for_file(MEDIA_PATH, None, None)
@@ -269,7 +269,7 @@ class ScannerTestCase(IsolatedAsyncioTestCase):
         # It's tricky to give a value to `scanner._script` that makes `_run_scan` return 5
         # directly, so we just mock it here.
         run_scan_mock = Mock(return_value=5)
-        self.scanner._run_scan = run_scan_mock  # type: ignore[assignment]
+        self.scanner._run_scan = run_scan_mock  # type: ignore[method-assign]
 
         # Scan the file, we'll check later that it wasn't cached.
         with self.assertRaises(FileDirtyError):
@@ -318,7 +318,7 @@ class ScannerTestCase(IsolatedAsyncioTestCase):
             return self.downloader_res
 
         scan_mock = Mock(side_effect=_scan_file)
-        self.scanner._scan_file = scan_mock  # type: ignore[assignment]
+        self.scanner._scan_file = scan_mock  # type: ignore[method-assign]
 
         # Request two scans of the same file at the same time.
         results = await asyncio.gather(


### PR DESCRIPTION
Fixes #52.

Commit messages have more details.

Drive-by fixes to remove twisted-related config, missed in #39.